### PR TITLE
add vignette key to metadata, enabling vignette to build on R CMD build

### DIFF
--- a/vignettes/TCGAloading.Rmd
+++ b/vignettes/TCGAloading.Rmd
@@ -1,5 +1,9 @@
 ---
 title: "TCGAloading"
+vignette: >
+  %\VignetteIndexEntry{TCGAloading}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
 author: "Marcel Ramos, Levi Waldron"
 date: "July 13, 2015"
 output: html_document


### PR DESCRIPTION
Hi, The package did not build with `R CMD build` or with the installation command I was trying to use on the AMI. I added some stuff to the YAML preamble that allows it to build.
